### PR TITLE
Azure Durable Function Logic Updates

### DIFF
--- a/.github/workflows/master_purge-orchestrations.yml
+++ b/.github/workflows/master_purge-orchestrations.yml
@@ -1,0 +1,42 @@
+name: Trigger Purge Orchestrations
+
+on:
+  workflow_dispatch:
+
+concurrency: 
+  group: purge-orchestrations
+  cancel-in-progress: true
+
+jobs:
+  trigger-refresh-operational-statuses:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Invoke PowerShell Script
+        id: invoke_script
+        shell: pwsh
+        working-directory: ./scripts
+        env:
+          AZURE_FUNCTION_KEY: ${{ secrets.AZURE_FUNCTION_KEY }}
+        continue-on-error: true
+        run: |
+          $FunctionUrl = "https://charlotte-third-places.azurewebsites.net/api/purge-orchestrations"
+          $FunctionKey = "$Env:AZURE_FUNCTION_KEY"
+          ./Invoke-AzureFunction.ps1 -FunctionUrl $FunctionUrl -FunctionKey $FunctionKey -TimeoutSeconds 300
+
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Azure Function call failed."
+            exit $LASTEXITCODE
+          } else {
+            Write-Output "Azure Function call succeeded."
+          }
+
+      - name: Check Script Result
+        if: always()
+        run: |
+          echo "Script execution completed with status: ${{ steps.invoke_script.outcome }}"
+          if ("${{ steps.invoke_script.outcome }}" -ne "success") {
+            exit 1
+          }

--- a/azure-function/function_app.py
+++ b/azure-function/function_app.py
@@ -1,7 +1,6 @@
 import os
 import json
 import logging
-import jsonpickle
 import azure.functions as func
 from outscraper import ApiClient
 from constants import SearchField
@@ -25,31 +24,76 @@ async def http_start(req: func.HttpRequest, client):
     return response
 
 
+@app.function_name(name="PurgeOrchestrations")
+@app.route(route="purge-orchestrations")
+@app.durable_client_input(client_name="client")
+async def purge_orchestrations(req: func.HttpRequest, client):
+    """
+    HTTP-triggered function to purge the history of all orchestration instances.
+
+    This function deletes the execution history of all orchestration instances managed by the Durable Functions framework.
+    Purging the history is useful when you need to reset the state of your orchestrations, especially after code changes
+    that could cause non-deterministic errors in existing instances.
+
+    Args:
+        req (func.HttpRequest): The HTTP request object.
+        client (DurableOrchestrationClient): The Durable Functions client for managing orchestrations.
+
+    Returns:
+        func.HttpResponse: A JSON response indicating the number of instances deleted.
+    """
+    logging.info("Received request to purge orchestration instances.")
+
+    try:
+        # Purge the history of all orchestration instances
+        purge_result = await client.purge_instance_history()
+
+        logging.info(f"Successfully purged orchestration instances. Instances deleted: {purge_result.instances_deleted}")
+
+        # Return a JSON response with the number of instances deleted
+        return func.HttpResponse(
+            json.dumps({
+                "message": "Purged orchestration instances.",
+                "instancesDeleted": purge_result.instances_deleted
+            }),
+            status_code=200,
+            mimetype="application/json"
+        )
+    except Exception as ex:
+        logging.error(f"Error occurred while purging orchestrations: {ex}", exc_info=True)
+        return func.HttpResponse(
+            json.dumps({
+                "message": "Failed to purge orchestration instances.",
+                "error": str(ex)
+            }),
+            status_code=500,
+            mimetype="application/json"
+        )
+
+
 @app.orchestration_trigger(context_name="context")
 def get_outscraper_reviews_orchestrator(context: df.DurableOrchestrationContext):
     try:
         logging.info("get_outscraper_reviews_orchestrator started.")
 
         tasks = []
-        airtable = AirtableClient()
-        OUTSCRAPER_API_KEY = os.environ['OUTSCRAPER_API_KEY']
-        outscraper = ApiClient(api_key=OUTSCRAPER_API_KEY)
+        activity_input = {}
+        all_third_places = yield context.call_activity('get_all_third_places', {})
 
-        activity_input = {
-            "airtable": jsonpickle.encode(airtable),
-            "outscraper": jsonpickle.encode(outscraper)
-        }
-
-        for place in airtable.all_third_places:
+        for place in all_third_places:
+            # Schedule activity functions for each place
             activity_input["place"] = place
             tasks.append(context.call_activity("get_outscraper_data_for_place", activity_input))
 
-        # This runs all tasks in parallel. Similar to asyncio.gather in Python.
+        # Run all tasks in parallel
         results = yield context.task_all(tasks)
-        logging.info(f"get_outscraper_reviews_orchestrator completed.")
+        logging.info("get_outscraper_reviews_orchestrator completed.")
+
+        # Determine overall success
         all_successful = all(result['status'] != 'failed' for result in results)
         custom_status = 'Succeeded' if all_successful else 'Failed'
         context.set_custom_status(custom_status)
+
         return results
     except Exception as ex:
         logging.error(f"Critical error in GetOutscraperReviews processing: {ex}", exc_info=True)
@@ -59,11 +103,17 @@ def get_outscraper_reviews_orchestrator(context: df.DurableOrchestrationContext)
 
 
 @app.activity_trigger(input_name="activityInput")
-def get_outscraper_data_for_place(activityInput):
+def get_all_third_places(activityInput):
+    airtable = AirtableClient()
+    return airtable.all_third_places
 
+
+@app.activity_trigger(input_name="activityInput")
+def get_outscraper_data_for_place(activityInput):
     place = activityInput['place']
-    airtable = jsonpickle.decode(activityInput['airtable'])
-    outscraper = jsonpickle.decode(activityInput['outscraper'])
+    airtable = AirtableClient()
+    OUTSCRAPER_API_KEY = os.environ['OUTSCRAPER_API_KEY']
+    outscraper = ApiClient(api_key=OUTSCRAPER_API_KEY)
 
     place_name = place['fields']['Place']
     logging.info(f"Getting reviews for place: {place_name}")
@@ -249,6 +299,7 @@ def enrich_airtable_base(req: func.HttpRequest) -> func.HttpResponse:
             status_code=403,
             mimetype="application/json"
         )
+
 
 @app.function_name(name="RefreshAirtableOperationalStatuses")
 @app.route(route="refresh-airtable-operational-statuses")

--- a/azure-function/requirements.txt
+++ b/azure-function/requirements.txt
@@ -11,4 +11,3 @@ azure-storage-file-datalake
 azure-identity
 outscraper
 azure-functions-durable
-jsonpickle

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -79,7 +79,7 @@ To debug the Azure Function locally, follow the guidance in the [quickstart](htt
 ### Using Real Storage
 
 1. Make sure in your `local.settings.json` file you have `AzureWebJobsStorage` set to the connection string of a storage account. The format is `DefaultEndpointsProtocol=https;AccountName=charlottethirdplaces;AccountKey=[AccountKeyHere];EndpointSuffix=core.windows.net`
-2. Debug `function_app.py` with a `launch.json` file that looks like the [below JSON](#launch-file). Right now this configuration should be setup already in the `.vscode` folder.
+2. Debug `function_app.py` with a `launch.json`. Right now this configuration should be setup already in the `.vscode` folder.
 3. Navigate to the Azure tab in the left bar and under Workspace expand Local Project. The function should be under there where you can right-click and execute it, providing your own body.
 
 ### Durable Functions


### PR DESCRIPTION
Stuff and thangs, including the following

* Making sure Azure Durable Functions don't peter out and return the failure seen from [this run](https://github.com/segunak/charlotte-third-places/actions/runs/12099874240/job/33737896614) when getting reviews via Outscraper. The learning here is that you've got to ensure everything that happens in your orchestrator function is deterministic by pushing logic to the activity functions and keep the orchestrator "pure"
* New Azure Function to purge all Durable Function Orchestrations as a "reset" tool.