### PR TITLE
Using Device Types For Size Instead Of Animals

### DIFF
--- a/charlotte-third-places/components/Icons.tsx
+++ b/charlotte-third-places/components/Icons.tsx
@@ -1,12 +1,11 @@
-// See https://react-icons.github.io/react-icons/. You can get Icons from just about every
-// pack out there from the same react-icons/PackName library.
+// See https://react-icons.github.io/react-icons/
 import { ArrowUp } from "lucide-react";
 import { FcGoogle } from "react-icons/fc";
 import { HiOutlineGlobeAlt } from "react-icons/hi";
 import { MdEditLocationAlt } from "react-icons/md";
 import { IconProps } from "@radix-ui/react-icons/dist/types";
-import { FaFilter, FaChessQueen, FaComment } from "react-icons/fa";
-import { FaLocationPin, FaMapPin, FaCirclePlus, FaMapLocationDot, FaShuffle, FaApple } from "react-icons/fa6";
+import { FaLocationPin, FaMapPin, FaMapLocationDot, FaShuffle, FaApple } from "react-icons/fa6";
+import { FaFilter, FaChessQueen, FaComment, FaMobileAlt, FaTabletAlt, FaDesktop, FaCircle} from "react-icons/fa";
 import {
   IoHome,
   IoHomeOutline,
@@ -37,6 +36,9 @@ export const Icons = {
   sun: LuSunMedium,
   moon: LuMoon,
   home: IoHome,
+  mobile: FaMobileAlt,
+  tablet: FaTabletAlt,
+  desktop: FaDesktop,
   shuffle: FaShuffle,
   share: LuShare,
   homeOutline: IoHomeOutline,
@@ -51,7 +53,7 @@ export const Icons = {
   comment: FaComment,
   queen: FaChessQueen,
   pin: FaLocationPin,
-  plus: FaCirclePlus,
+  circle: FaCircle,
   globe: HiOutlineGlobeAlt,
   map: IoMap,
   mapOutline: IoMapOutline,

--- a/charlotte-third-places/components/PlaceCard.tsx
+++ b/charlotte-third-places/components/PlaceCard.tsx
@@ -1,16 +1,17 @@
 import { Place } from "@/lib/types";
 import { FC, useMemo, memo } from "react";
+import { Icons } from "@/components/Icons"
 import { Button } from "@/components/ui/button"
 import { useModalContext } from "@/contexts/ModalContext";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 
-const neighborhoodEmoji = "🏘️"; // Houses emoji for Neighborhoods
+const neighborhoodEmoji = "🏘️";
 
-const sizeEmojiMap: { [key: string]: string } = {
-    "Small": "🐭",   // Mouse for Small
-    "Medium": "🐕",  // Dog for Medium
-    "Large": "🐘",   // Elephant for Large
-    "Unsure": "🤷"   // Person shrugging for Unsure
+const sizeIconMap: { [key: string]: React.ReactNode } = {
+    "Small": <Icons.mobile className="inline-block h-3 w-3" />,
+    "Medium": <Icons.tablet className="inline-block h-3 w-3" />,
+    "Large": <Icons.desktop className="inline-block h-3 w-3" />,
+    "Unsure": "🤷",
 };
 
 const typeEmojiMap: { [key: string]: string } = {
@@ -114,14 +115,21 @@ const AttributeTag: FC<AttributeTagProps> = memo(({ attribute }) => {
     // Memoize the result of getAttributeColors to avoid unnecessary recalculations
     const { bgColor, textColor } = useMemo(() => getAttributeColors(attribute), [attribute]);
 
-    // Determine if this is a size attribute or type attribute
-    const emoji = sizeEmojiMap[attribute] || typeEmojiMap[attribute] || "";
-    const displayText = `${attribute} ${emoji}`;
+    /* We want it to appear as "attribute iconOrEmoji" on one line If iconOrEmoji is a string (like "🤷" or "🍞"), 
+    do string concatenation. If it's a React node (like <Icons.mobile />), render it inline */
+    let displayContent;
+    const iconOrEmoji = sizeIconMap[attribute] ?? typeEmojiMap[attribute] ?? "";
+
+    if (typeof iconOrEmoji === "string") {
+        displayContent = `${attribute} ${iconOrEmoji}`;
+    } else {
+        displayContent = (<>{attribute} {iconOrEmoji}</>);
+    }
 
     return (
-        // Render the attribute inside a styled <span> element
+        // Render the attribute
         <span className={`${bgColor} ${textColor} text-balance text-xs sm:text-sm font-semibold mr-2 px-2.5 py-0.5 rounded-lg`}>
-            {displayText}
+            {displayContent}
         </span>
     );
 });
@@ -172,7 +180,7 @@ export const PlaceCard: FC<PlaceCardProps> = memo(({ place }) => {
                     <span className="flex justify-between">
                         <span className="text-sm block">
                             <strong>Neighborhood: </strong>
-                            {place?.neighborhood && <AttributeTag attribute={`${place.neighborhood} ${neighborhoodEmoji}`}/>}
+                            {place?.neighborhood && <AttributeTag attribute={`${place.neighborhood} ${neighborhoodEmoji}`} />}
                         </span>
 
                         <Button


### PR DESCRIPTION
I am torn on this. What emojis/icons best represent the sizes small, medium, and large? And by best represent, I mean in a way that's immediately recognizable, that reduces the cognitive load for users to near zero. I don't know. I used a mouse, dog, and elephant for small, medium, and large, but after thinking it over, I don't think that's exactly obvious to users. So I'm going with a mobile phone, tablet, and desktop for small, medium, and large. I think that's a bit better.

Regardless, the area in question has the literal text next to the icon, so no one should be confused. I just like trying to get the perfect feel for the icons.

![image](https://github.com/user-attachments/assets/28969fdf-b961-4418-b5ab-ed53d256bae2)
