### PR TITLE
Provide 4 Card Layout For Excessively Large Screens

### DIFF
--- a/charlotte-third-places/components/DataTable.tsx
+++ b/charlotte-third-places/components/DataTable.tsx
@@ -110,6 +110,7 @@ export function DataTable({ rowData }: DataTableProps) {
     // Aligns with Tailwind breakpoints at https://tailwindcss.com/docs/responsive-design
     // See tailwind.config.ts for 3xl and higher custom breakpoints
     const columnsPerRow = useMemo(() => {
+        if (windowWidth >= 2560) return 4;  // 4xl and higher -> 4 columns, 4 cards per row
         if (windowWidth >= 1920) return 3;  // 3xl and higher -> 3 columns, 3 cards per row
         if (windowWidth >= 1024) return 2;  // lg and higher  -> 2 columns, 2 cards per row
         return 1; // Anything smaller than lg, 1 column, 1 card per row
@@ -149,7 +150,7 @@ export function DataTable({ rowData }: DataTableProps) {
                 <div className="flex flex-wrap -mx-2">
                     {group.map((place: any, index: number) => (
                         // The breakpoints here are tied to the columnsPerRow calculation
-                        <div key={index} className="w-full lg:w-1/2 3xl:w-1/3 px-2 mb-4">
+                        <div key={index} className="w-full lg:w-1/2 3xl:w-1/3 4xl:w-1/4 px-2 mb-4">
                             <PlaceCard place={place} />
                         </div>
                     ))}


### PR DESCRIPTION
I sometimes use the [49 inch Samsung Odyssey G9 Ultrawide Monitor](https://www.google.com/search?q=Samsung+Odyssey+G). This code is for my people in [ultrawidemasterrace](https://www.reddit.com/r/ultrawidemasterrace/). We might be a small community, but I'm determined to make sure any site I own looks good on an ridiculously wide screen for my peeps. Perhaps one day I'll be fortunate enough to try out the [55 inch Samsung Galaxy Ark](https://www.google.com/search?q=Samsung+Galaxy+Ark)