### PR TITLE
Safe Area Handling to Prevent Filter Drawer From Overlapping With iOS Home Button

### DIFF
--- a/charlotte-third-places/app/layout.tsx
+++ b/charlotte-third-places/app/layout.tsx
@@ -68,6 +68,7 @@ interface RootLayoutProps {
 
 export const viewport: Viewport = {
   themeColor: 'white',
+  viewportFit: 'cover',
 }
 
 export default function RootLayout({ children }: RootLayoutProps) {

--- a/charlotte-third-places/components/FilterDrawer.tsx
+++ b/charlotte-third-places/components/FilterDrawer.tsx
@@ -72,7 +72,7 @@ export function FilterDrawer({
         )}
         <span className="sr-only">Open Filters</span> {/* Added for accessibility */}
       </Button>
-      <DrawerContent>
+      <DrawerContent className="pb-safe">
         {/* Overlay to absorb all pointer events when anyDropdownOpen is true */}
         {anyDropdownOpen && (
           <div
@@ -89,7 +89,7 @@ export function FilterDrawer({
         <DrawerHeader>
           <DrawerTitle></DrawerTitle>
         </DrawerHeader>
-        <div className="space-y-4 px-4 pb-4">
+        <div className="space-y-4 px-4">
           {showSort && (
             <div className="space-y-4">
               <h2 className="text-center text-lg font-semibold leading-none tracking-tight">Sort</h2>

--- a/charlotte-third-places/styles/globals.css
+++ b/charlotte-third-places/styles/globals.css
@@ -30,6 +30,12 @@
   .text-apple {
     color: var(--apple-icon-color);
   }
+
+  /* Safe area utilities */
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
 }
 
 @layer base {


### PR DESCRIPTION
This pull request introduces improvements to accessibility, safe area handling, and layout styling in the `charlotte-third-places` project. The most significant changes include adding safe area utilities to the global styles, enhancing accessibility in the `FilterDrawer` component, and updating the viewport configuration.

### Accessibility Improvements:

* [`charlotte-third-places/components/FilterDrawer.tsx`](diffhunk://#diff-b3b9736dae464e360e9e7961782056b361b5ca2e15689010053bd72de3b55778L75-R75): Added a visually hidden `<span>` with "Open Filters" for screen readers to improve accessibility.

### Safe Area Handling:

* [`charlotte-third-places/styles/globals.css`](diffhunk://#diff-68f97aee718e6985ca3af2a2a1e4a988e88c415dbd530d1387238f4b46d1f189R33-R38): Introduced a `.pb-safe` utility class that uses `env(safe-area-inset-bottom)` to ensure proper padding for devices with safe areas.
* [`charlotte-third-places/components/FilterDrawer.tsx`](diffhunk://#diff-b3b9736dae464e360e9e7961782056b361b5ca2e15689010053bd72de3b55778L75-R75): Applied the `.pb-safe` class to the `DrawerContent` element to account for safe area padding.

### Layout and Styling Updates:

* [`charlotte-third-places/app/layout.tsx`](diffhunk://#diff-25d08c8213eb46ebac303ff35cb1d7645f3632f1f223e590beb89e985a188705R71): Added `viewportFit: 'cover'` to the `viewport` configuration to optimize layout for devices with non-rectangular screens.
* [`charlotte-third-places/components/FilterDrawer.tsx`](diffhunk://#diff-b3b9736dae464e360e9e7961782056b361b5ca2e15689010053bd72de3b55778L92-R92): Removed redundant bottom padding from the sorting section to streamline the layout.…lose button on non Safari browsers