### PR TITLE
New Workflow To Force Refresh All Data for Given Place

### DIFF
--- a/.github/workflows/master_trigger-refresh-single-place.yml
+++ b/.github/workflows/master_trigger-refresh-single-place.yml
@@ -1,0 +1,82 @@
+name: Trigger Refresh Single Place
+
+on:
+  workflow_call:
+    inputs:
+      place_id:
+        description: 'Google Maps Place ID of the place to refresh'
+        required: true
+        type: string
+      provider_type:
+        description: 'Provider type for data refresh'
+        required: false
+        default: 'outscraper'
+        type: string
+      city:
+        description: 'City for caching'
+        required: false
+        default: 'charlotte'
+        type: string
+  workflow_dispatch:
+    inputs:
+      place_id:
+        description: 'Google Maps Place ID of the place to refresh'
+        required: true
+        type: string
+      provider_type:
+        description: 'Provider type for data refresh'
+        required: false
+        default: 'outscraper'
+        type: string
+      city:
+        description: 'City for caching'
+        required: false
+        default: 'charlotte'
+        type: string
+
+# Ensures that only one instance of this workflow runs at a time
+concurrency: 
+  group: refresh-single-place
+  cancel-in-progress: true
+
+jobs:
+  trigger-refresh-single-place:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Invoke PowerShell Script
+        id: invoke_script
+        working-directory: ./scripts
+        shell: pwsh
+        env:
+          AZURE_FUNCTION_KEY: ${{ secrets.AZURE_FUNCTION_KEY }}
+        run: |
+          $placeId = "${{ github.event.inputs.place_id }}"
+          $providerType = "${{ github.event.inputs.provider_type || 'outscraper' }}"
+          $city = "${{ github.event.inputs.city || 'charlotte' }}"
+          
+          # Validate required place_id parameter
+          if ([string]::IsNullOrWhiteSpace($placeId)) {
+            Write-Error "place_id parameter is required (Google Maps Place Id)"
+            exit 1
+          }
+          
+          $FunctionUrl = "https://third-places-data.azurewebsites.net/api/refresh-single-place?place_id=$placeId&provider_type=$providerType&city=$city"
+          
+          Write-Host "Using orchestrator URL: $FunctionUrl"
+          
+          ./Invoke-AzureDurableFunction.ps1 -FunctionUrl $FunctionUrl -FunctionKey "$Env:AZURE_FUNCTION_KEY" -TimeoutSeconds 7200
+
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Check Script Result
+        if: always()
+        run: |
+          echo "Script execution completed with status: ${{ steps.invoke_script.outcome }}"
+          if ("${{ steps.invoke_script.outcome }}" -ne "success") {
+            exit 1
+          }


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to trigger a data refresh for a single place using a PowerShell script. The workflow is designed to be reusable and supports both manual and programmatic triggers. Below is a summary of the key changes:

### New GitHub Actions Workflow

* **New Workflow File**: Added `.github/workflows/master_trigger-refresh-single-place.yml` to define a reusable workflow that refreshes data for a specific place using its Google Maps Place ID.
* **Inputs Configuration**: Supports inputs for `place_id` (required), `provider_type` (optional, defaults to `'outscraper'`), and `city` (optional, defaults to `'charlotte'`). These inputs are available for both `workflow_call` and `workflow_dispatch` triggers.
* **Concurrency Control**: Ensures only one instance of the workflow runs at a time by using a `concurrency` group named `refresh-single-place`.

### Job Details

* **Environment Setup**: Runs on `windows-latest`, checks out the repository, and invokes a PowerShell script located in the `./scripts` directory.
* **PowerShell Script Execution**: Validates the `place_id` input, constructs an Azure Function URL with the provided parameters, and invokes the function using the `Invoke-AzureDurableFunction