### PR TITLE
Enhance iOS build workflow and MobileNavigation component

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -16,6 +16,11 @@ jobs:
           cd ios/src
           pod install
 
+      - name: Set build number from run number
+        run: |
+          sed -i '' "s/CURRENT_PROJECT_VERSION = [0-9]*/CURRENT_PROJECT_VERSION = ${{ github.run_number }}/g" "ios/src/Third Places.xcodeproj/project.pbxproj"
+          echo "Build number set to ${{ github.run_number }}"
+
       - name: Create .p12 from key and certificate
         run: |
           echo "${{ secrets.IOS_DISTRIBUTION_KEY_BASE64 }}" | base64 --decode > ios_distribution.key

--- a/charlotte-third-places/components/MobileNavigation.tsx
+++ b/charlotte-third-places/components/MobileNavigation.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Icons } from "@/components/Icons";
 import { usePathname } from 'next/navigation';
@@ -7,6 +8,14 @@ import { usePathname } from 'next/navigation';
 export function MobileNavigation() {
   const pathname = usePathname();
   const iconClass = "h-5 w-5";
+
+  // In standalone mode (PWA installed or native iOS/Android wrapper), the native
+  // container already handles the safe area inset for the home indicator. Adding
+  // pb-safe on top of that creates a visible gap. Only apply pb-safe in browser mode.
+  const [isStandalone, setIsStandalone] = useState(false);
+  useEffect(() => {
+    setIsStandalone(window.matchMedia('(display-mode: standalone)').matches);
+  }, []);
 
   const navItems = [
     {
@@ -43,7 +52,7 @@ export function MobileNavigation() {
 
   return (
     <>
-      <nav className="sm:hidden fixed bottom-0 left-0 right-0 bg-background border-t border-border z-50 pb-safe">
+      <nav className={`sm:hidden fixed bottom-0 left-0 right-0 bg-background border-t border-border z-50 ${isStandalone ? '' : 'pb-safe'}`}>
         <div className="grid grid-cols-5 h-14">
           {navItems.map((item) => (
             <Link href={item.href} key={item.href} className="flex flex-col items-center justify-center">
@@ -57,7 +66,7 @@ export function MobileNavigation() {
           ))}
         </div>
       </nav>
-      <div className="sm:hidden h-14 pb-safe" aria-hidden="true" />
+      <div className={`sm:hidden h-14 ${isStandalone ? '' : 'pb-safe'}`} aria-hidden="true" />
     </>
   );
 }

--- a/charlotte-third-places/components/MobileNavigation.tsx
+++ b/charlotte-third-places/components/MobileNavigation.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useState, useEffect } from 'react';
 import { Icons } from "@/components/Icons";
 import { usePathname } from 'next/navigation';
 

--- a/ios/src/Third Places.xcodeproj/project.pbxproj
+++ b/ios/src/Third Places.xcodeproj/project.pbxproj
@@ -372,7 +372,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Third Places/Entitlements/Entitlements.plist";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Third Places/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -381,7 +381,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.charlottethirdplaces.app";
 				PRODUCT_NAME = "ThirdPlaces";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -400,7 +400,7 @@
 				CLANG_ENABLE_MODULES = NO;
 				CODE_SIGN_ENTITLEMENTS = "Third Places/Entitlements/Entitlements.plist";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Third Places/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -409,7 +409,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.charlottethirdplaces.app";
 				PRODUCT_NAME = "ThirdPlaces";
 				SUPPORTS_MACCATALYST = YES;

--- a/ios/src/Third Places/Assets.xcassets/LaunchIcon.imageset/Contents.json
+++ b/ios/src/Third Places/Assets.xcassets/LaunchIcon.imageset/Contents.json
@@ -2,7 +2,18 @@
   "images" : [
     {
       "filename" : "splash.png",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "filename" : "splash.png",
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "filename" : "splash.png",
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {
@@ -10,6 +21,7 @@
     "version" : 1
   },
   "properties" : {
-    "compression-type" : "automatic"
+    "compression-type" : "automatic",
+    "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to both the iOS build process and the mobile navigation UI, as well as updates to the app's asset configuration. The most significant changes are the dynamic setting of the iOS build number during CI builds, enhanced handling of safe area insets in the mobile navigation for standalone (PWA/native) mode, and the addition of missing asset scales for launch icons.

**iOS Build Process Improvements:**
* The GitHub Actions workflow (`ios-build.yml`) now automatically sets the iOS build number (`CURRENT_PROJECT_VERSION`) to match the workflow run number, ensuring unique build numbers for each CI build.
* The `CURRENT_PROJECT_VERSION` in `project.pbxproj` is updated from 1 to 2, likely as part of the new build versioning approach. [[1]](diffhunk://#diff-0a698136a23e1d4cbf1f65d35ba9e0b41d24c5efe67dfcfef0cbe48672b6ed19L375-R375) [[2]](diffhunk://#diff-0a698136a23e1d4cbf1f65d35ba9e0b41d24c5efe67dfcfef0cbe48672b6ed19L384-R384) [[3]](diffhunk://#diff-0a698136a23e1d4cbf1f65d35ba9e0b41d24c5efe67dfcfef0cbe48672b6ed19L403-R403) [[4]](diffhunk://#diff-0a698136a23e1d4cbf1f65d35ba9e0b41d24c5efe67dfcfef0cbe48672b6ed19L412-R412)

**Mobile Navigation UI Enhancements:**
* The `MobileNavigation` component now detects if the app is running in standalone mode (PWA or native wrapper) and conditionally applies the `pb-safe` class. This prevents double safe area insets, fixing unwanted gaps at the bottom in standalone mode. [[1]](diffhunk://#diff-dcadd95e9bde6f6525436bd562e29d481b5cf7355c468a88ee8e2f9d9629151bR4-R19) [[2]](diffhunk://#diff-dcadd95e9bde6f6525436bd562e29d481b5cf7355c468a88ee8e2f9d9629151bL46-R55) [[3]](diffhunk://#diff-dcadd95e9bde6f6525436bd562e29d481b5cf7355c468a88ee8e2f9d9629151bL60-R69)

**Asset Configuration Updates:**
* The launch icon asset (`Contents.json`) now includes 1x, 2x, and 3x scale variants and sets `preserves-vector-representation` to `true`, improving image quality across devices.